### PR TITLE
Add support for wp_date() function

### DIFF
--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -211,7 +211,7 @@ $submenu['plugins.php'][5]  = array( __('Installed Plugins'), 'activate_plugins'
 		/* translators: upload new plugin */
 		$submenu['plugins.php'][7] = array( _x('Upload', 'plugin'), 'install_plugins', 'plugin-install.php?tab=upload' );
 		/* translators: add new plugin from WP plugin repository */
-		$submenu['plugins.php'][10] = array( _x('Add WP Plugin', 'plugin'), 'install_plugins', 'plugin-install.php?s=classicpress&tab=search&type=tag' );
+		$submenu['plugins.php'][10] = array( _x('Add WP Plugin', 'plugin'), 'install_plugins', 'plugin-install.php?s=classicpress&tab=search&type=term' );
 		$submenu['plugins.php'][15] = array( _x('Editor', 'plugin editor'), 'edit_plugins', 'plugin-editor.php' );
 	}
 

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -211,7 +211,7 @@ $submenu['plugins.php'][5]  = array( __('Installed Plugins'), 'activate_plugins'
 		/* translators: upload new plugin */
 		$submenu['plugins.php'][7] = array( _x('Upload', 'plugin'), 'install_plugins', 'plugin-install.php?tab=upload' );
 		/* translators: add new plugin from WP plugin repository */
-		$submenu['plugins.php'][10] = array( _x('Add WP Plugin', 'plugin'), 'install_plugins', 'plugin-install.php' );
+		$submenu['plugins.php'][10] = array( _x('Add WP Plugin', 'plugin'), 'install_plugins', 'plugin-install.php?s=classicpress&tab=search&type=tag' );
 		$submenu['plugins.php'][15] = array( _x('Editor', 'plugin editor'), 'edit_plugins', 'plugin-editor.php' );
 	}
 

--- a/src/wp-admin/network/menu.php
+++ b/src/wp-admin/network/menu.php
@@ -60,7 +60,7 @@ if ( current_user_can( 'update_plugins' ) && $update_data['counts']['plugins'] )
 }
 $submenu['plugins.php'][5]  = array( __('Installed Plugins'), 'manage_network_plugins', 'plugins.php' );
 $submenu['plugins.php'][7] = array( _x('Upload', 'plugin'), 'install_plugins', 'plugin-install.php?tab=upload' );
-$submenu['plugins.php'][10] = array( _x('Add WP Plugin', 'plugin'), 'install_plugins', 'plugin-install.php' );
+$submenu['plugins.php'][10] = array( _x('Add WP Plugin', 'plugin'), 'install_plugins', 'plugin-install.php?s=classicpress&tab=search&type=tag' );
 $submenu['plugins.php'][15] = array( _x('Editor', 'plugin editor'), 'edit_plugins', 'plugin-editor.php' );
 
 $menu[25] = array(__('Settings'), 'manage_network_options', 'settings.php', '', 'menu-top menu-icon-settings', 'menu-settings', 'dashicons-admin-settings');

--- a/src/wp-admin/network/menu.php
+++ b/src/wp-admin/network/menu.php
@@ -60,7 +60,7 @@ if ( current_user_can( 'update_plugins' ) && $update_data['counts']['plugins'] )
 }
 $submenu['plugins.php'][5]  = array( __('Installed Plugins'), 'manage_network_plugins', 'plugins.php' );
 $submenu['plugins.php'][7] = array( _x('Upload', 'plugin'), 'install_plugins', 'plugin-install.php?tab=upload' );
-$submenu['plugins.php'][10] = array( _x('Add WP Plugin', 'plugin'), 'install_plugins', 'plugin-install.php?s=classicpress&tab=search&type=tag' );
+$submenu['plugins.php'][10] = array( _x('Add WP Plugin', 'plugin'), 'install_plugins', 'plugin-install.php?s=classicpress&tab=search&type=term' );
 $submenu['plugins.php'][15] = array( _x('Editor', 'plugin editor'), 'edit_plugins', 'plugin-editor.php' );
 
 $menu[25] = array(__('Settings'), 'manage_network_options', 'settings.php', '', 'menu-top menu-icon-settings', 'menu-settings', 'dashicons-admin-settings');

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -525,7 +525,7 @@ echo esc_html( $title );
 if ( ( ! is_multisite() || is_network_admin() ) && current_user_can( 'install_plugins' ) ) {
 ?>
 	<a href="<?php echo self_admin_url( 'plugin-install.php?tab=upload' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Upload', 'plugin' ); ?></a>
-	<a href="<?php echo self_admin_url( 'plugin-install.php' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Add WP Plugin', 'plugin' ); ?></a>
+	<a href="<?php echo self_admin_url( 'plugin-install.php?s=classicpress&tab=search&type=tag' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Add WP Plugin', 'plugin' ); ?></a>
 <?php
 }
 

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -525,7 +525,7 @@ echo esc_html( $title );
 if ( ( ! is_multisite() || is_network_admin() ) && current_user_can( 'install_plugins' ) ) {
 ?>
 	<a href="<?php echo self_admin_url( 'plugin-install.php?tab=upload' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Upload', 'plugin' ); ?></a>
-	<a href="<?php echo self_admin_url( 'plugin-install.php?s=classicpress&tab=search&type=tag' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Add WP Plugin', 'plugin' ); ?></a>
+	<a href="<?php echo self_admin_url( 'plugin-install.php?s=classicpress&tab=search&type=term' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Add WP Plugin', 'plugin' ); ?></a>
 <?php
 }
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -70,6 +70,57 @@ function current_time( $type, $gmt = 0 ) {
 }
 
 /**
+ * Retrieves the timezone of the site as a string.
+ *
+ * Uses the `timezone_string` option to get a proper timezone name if available,
+ * otherwise falls back to a manual UTC ± offset.
+ *
+ * Example return values:
+ *
+ *  - 'Europe/Rome'
+ *  - 'America/North_Dakota/New_Salem'
+ *  - 'UTC'
+ *  - '-06:30'
+ *  - '+00:00'
+ *  - '+08:45'
+ *
+ * @since 5.3.0
+ *
+ * @return string PHP timezone name or a ±HH:MM offset.
+ */
+function wp_timezone_string() {
+	$timezone_string = get_option( 'timezone_string' );
+
+	if ( $timezone_string ) {
+		return $timezone_string;
+	}
+
+	$offset  = (float) get_option( 'gmt_offset' );
+	$hours   = (int) $offset;
+	$minutes = ( $offset - $hours );
+
+	$sign      = ( $offset < 0 ) ? '-' : '+';
+	$abs_hour  = abs( $hours );
+	$abs_mins  = abs( $minutes * 60 );
+	$tz_offset = sprintf( '%s%02d:%02d', $sign, $abs_hour, $abs_mins );
+
+	return $tz_offset;
+}
+
+/**
+ * Retrieves the timezone of the site as a `DateTimeZone` object.
+ *
+ * Timezone can be based on a PHP timezone string or a ±HH:MM offset.
+ *
+ * @since 5.3.0
+ *
+ * @return DateTimeZone Timezone object.
+ */
+function wp_timezone() {
+	return new DateTimeZone( wp_timezone_string() );
+}
+
+/**
  * Retrieve the date in localized format, based on timestamp.
  *
  * If the locale specifies the locale month and weekday, then the locale will
@@ -148,6 +199,104 @@ function date_i18n( $dateformatstring, $unixtimestamp = false, $gmt = false ) {
 	 */
 	$j = apply_filters( 'date_i18n', $j, $req_format, $i, $gmt );
 	return $j;
+}
+
+/**
+ * Retrieves the date, in localized format.
+ *
+ * This is a newer function, intended to replace `date_i18n()` without legacy quirks in it.
+ *
+ * Note that, unlike `date_i18n()`, this function accepts a true Unix timestamp, not summed
+ * with timezone offset.
+ *
+ * @since 5.3.0
+ *
+ * @global WP_Locale $wp_locale WordPress date and time locale object.
+ *
+ * @param string       $format    PHP date format.
+ * @param int          $timestamp Optional. Unix timestamp. Defaults to current time.
+ * @param DateTimeZone $timezone  Optional. Timezone to output result in. Defaults to timezone
+ *                                from site settings.
+ * @return string|false The date, translated if locale specifies it. False on invalid timestamp input.
+ */
+function wp_date( $format, $timestamp = null, $timezone = null ) {
+	global $wp_locale;
+
+	if ( null === $timestamp ) {
+		$timestamp = time();
+	} elseif ( ! is_numeric( $timestamp ) ) {
+		return false;
+	}
+
+	if ( ! $timezone ) {
+		$timezone = wp_timezone();
+	}
+
+	$datetime = date_create( '@' . $timestamp );
+	$datetime->setTimezone( $timezone );
+
+	if ( empty( $wp_locale->month ) || empty( $wp_locale->weekday ) ) {
+		$date = $datetime->format( $format );
+	} else {
+		// We need to unpack shorthand `r` format because it has parts that might be localized.
+		$format = preg_replace( '/(?<!\\\\)r/', DATE_RFC2822, $format );
+
+		$new_format    = '';
+		$format_length = strlen( $format );
+		$month         = $wp_locale->get_month( $datetime->format( 'm' ) );
+		$weekday       = $wp_locale->get_weekday( $datetime->format( 'w' ) );
+
+		for ( $i = 0; $i < $format_length; $i ++ ) {
+			switch ( $format[ $i ] ) {
+				case 'D':
+					$new_format .= addcslashes( $wp_locale->get_weekday_abbrev( $weekday ), '\\A..Za..z' );
+					break;
+				case 'F':
+					$new_format .= addcslashes( $month, '\\A..Za..z' );
+					break;
+				case 'l':
+					$new_format .= addcslashes( $weekday, '\\A..Za..z' );
+					break;
+				case 'M':
+					$new_format .= addcslashes( $wp_locale->get_month_abbrev( $month ), '\\A..Za..z' );
+					break;
+				case 'a':
+					$new_format .= addcslashes( $wp_locale->get_meridiem( $datetime->format( 'a' ) ), '\\A..Za..z' );
+					break;
+				case 'A':
+					$new_format .= addcslashes( $wp_locale->get_meridiem( $datetime->format( 'A' ) ), '\\A..Za..z' );
+					break;
+				case '\\':
+					$new_format .= $format[ $i ];
+
+					// If character follows a slash, we add it without translating.
+					if ( $i < $format_length ) {
+						$new_format .= $format[ ++$i ];
+					}
+					break;
+				default:
+					$new_format .= $format[ $i ];
+					break;
+			}
+		}
+
+		$date = $datetime->format( $new_format );
+		$date = wp_maybe_decline_date( $date, $format );
+	}
+
+	/**
+	 * Filters the date formatted based on the locale.
+	 *
+	 * @since 5.3.0
+	 *
+	 * @param string       $date      Formatted date string.
+	 * @param string       $format    Format to display the date.
+	 * @param int          $timestamp Unix timestamp.
+	 * @param DateTimeZone $timezone  Timezone.
+	 */
+	$date = apply_filters( 'wp_date', $date, $format, $timestamp, $timezone );
+
+	return $date;
 }
 
 /**


### PR DESCRIPTION
## Description
WP 5.3 has introduced a new, non-legacy-dependent Date Function `wp_date`.

This PR simply adds support for `wp_date`. It does NOT change the core code to _use_ that new function, but, if any plugin relies on it, it will be there, thus avoiding fatal errors.

To support `wp_date` 2 more functions have to be added (included in this PR):
- `wp_timezone`
- `wp_timezone_string`

This PR is not a classic back port, because it does _not_ make Core use these new functions, it just adds support for them, which is all we need to have Plugins (and other code) working with CP.

## Motivation and context
Several _important_ plugins such as Postmark rely on this function(s). This means, you can't use Postmark on CP - Postmark is the _leading_ solution for Mail Sending on VPS servers that do not come with inbuilt mailers.
All my sites use postmark, actually all sites created with a VPS usually use it. None of these sites can use CP due to the lack of the function which this PR adds support for.

## How has this been tested?
This PR is already merged to my own sites, and it works just fine on these sites.

## Types of changes
- New feature